### PR TITLE
Fix Windows warnings

### DIFF
--- a/unuran/src/methods/mvtdr_init.h
+++ b/unuran/src/methods/mvtdr_init.h
@@ -1757,7 +1757,7 @@ _unur_mvtdr_etable_new( struct unur_gen *gen, int size )
   GEN->etable_size = size;
 
   /* make root */
-  GEN->etable = malloc( size * sizeof(E_TABLE*) );
+  GEN->etable = malloc( size * sizeof(E_TABLE) );
   if (GEN->etable==NULL) {
     _unur_error(gen->genid,UNUR_ERR_MALLOC,""); return UNUR_ERR_MALLOC; }
 


### PR DESCRIPTION
Related issue: https://github.com/rgommers/scipy/issues/120

This PR aims to fix the following warning:
```
[516/1557] Compiling C object scipy/stats/_unuran/unuran_wrapper.cp39-win_amd64.pyd.p/.._..__lib_unuran_unuran_src_methods_mvtdr.c.obj
In file included from ../scipy/_lib/unuran/unuran/src/methods/mvtdr.c:330:
In function '_unur_mvtdr_etable_new',
    inlined from '_unur_mvtdr_triangulate' at ../scipy/_lib/unuran/unuran/src/methods/mvtdr_init.h:978:11:
../scipy/_lib/unuran/unuran/src/methods/mvtdr_init.h:1760:17: warning: argument 1 value '18446744073709551608' exceeds maximum object size 9223372036854775807 [-Walloc-size-larger-than=]
 1760 |   GEN->etable = malloc( size * sizeof(E_TABLE*) );
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from ..\scipy\_lib\unuran\unuran\src/unur_source.h:71,
                 from ../scipy/_lib/unuran/unuran/src/methods/mvtdr.c:50:
../scipy/_lib/unuran/unuran/src/methods/mvtdr_init.h: In function '_unur_mvtdr_triangulate':
c:/rtools40/ucrt64/x86_64-w64-mingw32/include/stdlib.h:531:17: note: in a call to allocation function 'malloc' declared here
  531 |   void *__cdecl malloc(size_t _Size);
      |                 ^~~~~~
```