### PR TITLE
Add copyright back

### DIFF
--- a/unuran/src/distr/cemp.c
+++ b/unuran/src/distr/cemp.c
@@ -15,7 +15,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/distr/cemp.h
+++ b/unuran/src/distr/cemp.h
@@ -15,7 +15,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/distr/condi.c
+++ b/unuran/src/distr/condi.c
@@ -14,7 +14,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/distr/condi.h
+++ b/unuran/src/distr/condi.h
@@ -16,7 +16,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/distr/cont.c
+++ b/unuran/src/distr/cont.c
@@ -14,7 +14,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/distr/cont.h
+++ b/unuran/src/distr/cont.h
@@ -15,7 +15,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/distr/corder.h
+++ b/unuran/src/distr/corder.h
@@ -16,7 +16,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/distr/cvec.c
+++ b/unuran/src/distr/cvec.c
@@ -14,7 +14,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/distr/cvec.h
+++ b/unuran/src/distr/cvec.h
@@ -15,7 +15,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/distr/cvemp.c
+++ b/unuran/src/distr/cvemp.c
@@ -15,7 +15,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/distr/cvemp.h
+++ b/unuran/src/distr/cvemp.h
@@ -15,7 +15,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/distr/cxtrans.c
+++ b/unuran/src/distr/cxtrans.c
@@ -17,7 +17,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/distr/cxtrans.h
+++ b/unuran/src/distr/cxtrans.h
@@ -16,7 +16,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/distr/discr.c
+++ b/unuran/src/distr/discr.c
@@ -14,7 +14,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/distr/discr.h
+++ b/unuran/src/distr/discr.h
@@ -15,7 +15,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/distr/distr.c
+++ b/unuran/src/distr/distr.c
@@ -16,7 +16,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/distr/distr.h
+++ b/unuran/src/distr/distr.h
@@ -14,7 +14,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/distr/distr_info.c
+++ b/unuran/src/distr/distr_info.c
@@ -10,7 +10,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/distr/distr_source.h
+++ b/unuran/src/distr/distr_source.h
@@ -15,7 +15,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/distr/distr_struct.h
+++ b/unuran/src/distr/distr_struct.h
@@ -14,7 +14,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/distr/matr.c
+++ b/unuran/src/distr/matr.c
@@ -14,7 +14,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/distr/matr.h
+++ b/unuran/src/distr/matr.h
@@ -15,7 +15,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/distributions/c_F.c
+++ b/unuran/src/distributions/c_F.c
@@ -27,7 +27,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/distributions/c_beta.c
+++ b/unuran/src/distributions/c_beta.c
@@ -44,7 +44,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/distributions/c_beta_gen.c
+++ b/unuran/src/distributions/c_beta_gen.c
@@ -10,7 +10,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/distributions/c_cauchy.c
+++ b/unuran/src/distributions/c_cauchy.c
@@ -27,7 +27,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/distributions/c_chi.c
+++ b/unuran/src/distributions/c_chi.c
@@ -27,7 +27,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/distributions/c_chi_gen.c
+++ b/unuran/src/distributions/c_chi_gen.c
@@ -11,7 +11,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/distributions/c_chisquare.c
+++ b/unuran/src/distributions/c_chisquare.c
@@ -26,7 +26,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/distributions/c_exponential.c
+++ b/unuran/src/distributions/c_exponential.c
@@ -40,7 +40,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/distributions/c_exponential_gen.c
+++ b/unuran/src/distributions/c_exponential_gen.c
@@ -10,7 +10,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/distributions/c_extremeI.c
+++ b/unuran/src/distributions/c_extremeI.c
@@ -46,7 +46,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/distributions/c_extremeII.c
+++ b/unuran/src/distributions/c_extremeII.c
@@ -48,7 +48,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/distributions/c_gamma.c
+++ b/unuran/src/distributions/c_gamma.c
@@ -42,7 +42,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/distributions/c_gamma_gen.c
+++ b/unuran/src/distributions/c_gamma_gen.c
@@ -10,7 +10,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/distributions/c_gig.c
+++ b/unuran/src/distributions/c_gig.c
@@ -59,7 +59,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/distributions/c_gig2.c
+++ b/unuran/src/distributions/c_gig2.c
@@ -47,7 +47,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/distributions/c_gig_gen.c
+++ b/unuran/src/distributions/c_gig_gen.c
@@ -10,7 +10,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/distributions/c_hyperbolic.c
+++ b/unuran/src/distributions/c_hyperbolic.c
@@ -26,7 +26,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/distributions/c_laplace.c
+++ b/unuran/src/distributions/c_laplace.c
@@ -40,7 +40,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/distributions/c_logistic.c
+++ b/unuran/src/distributions/c_logistic.c
@@ -42,7 +42,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/distributions/c_lomax.c
+++ b/unuran/src/distributions/c_lomax.c
@@ -27,7 +27,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/distributions/c_pareto.c
+++ b/unuran/src/distributions/c_pareto.c
@@ -27,7 +27,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/distributions/c_rayleigh.c
+++ b/unuran/src/distributions/c_rayleigh.c
@@ -26,7 +26,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/distributions/c_slash.c
+++ b/unuran/src/distributions/c_slash.c
@@ -26,7 +26,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/distributions/c_student_gen.c
+++ b/unuran/src/distributions/c_student_gen.c
@@ -10,7 +10,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/distributions/c_triangular.c
+++ b/unuran/src/distributions/c_triangular.c
@@ -27,7 +27,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/distributions/c_uniform.c
+++ b/unuran/src/distributions/c_uniform.c
@@ -27,7 +27,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/distributions/c_weibull.c
+++ b/unuran/src/distributions/c_weibull.c
@@ -43,7 +43,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/distributions/d_binomial.c
+++ b/unuran/src/distributions/d_binomial.c
@@ -27,7 +27,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/distributions/d_binomial_gen.c
+++ b/unuran/src/distributions/d_binomial_gen.c
@@ -10,7 +10,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/distributions/d_geometric.c
+++ b/unuran/src/distributions/d_geometric.c
@@ -26,7 +26,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/distributions/d_hypergeometric.c
+++ b/unuran/src/distributions/d_hypergeometric.c
@@ -28,7 +28,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/distributions/d_hypergeometric_gen.c
+++ b/unuran/src/distributions/d_hypergeometric_gen.c
@@ -10,7 +10,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/distributions/d_logarithmic.c
+++ b/unuran/src/distributions/d_logarithmic.c
@@ -26,7 +26,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/distributions/d_logarithmic_gen.c
+++ b/unuran/src/distributions/d_logarithmic_gen.c
@@ -10,7 +10,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/distributions/d_negativebinomial.c
+++ b/unuran/src/distributions/d_negativebinomial.c
@@ -27,7 +27,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/distributions/d_poisson.c
+++ b/unuran/src/distributions/d_poisson.c
@@ -26,7 +26,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/distributions/d_poisson_gen.c
+++ b/unuran/src/distributions/d_poisson_gen.c
@@ -10,7 +10,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/distributions/d_zipf.c
+++ b/unuran/src/distributions/d_zipf.c
@@ -28,7 +28,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/distributions/d_zipf_gen.c
+++ b/unuran/src/distributions/d_zipf_gen.c
@@ -10,7 +10,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/distributions/m_correlation.c
+++ b/unuran/src/distributions/m_correlation.c
@@ -10,7 +10,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/distributions/unur_distributions.h
+++ b/unuran/src/distributions/unur_distributions.h
@@ -43,7 +43,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/distributions/unur_distributions_source.h
+++ b/unuran/src/distributions/unur_distributions_source.h
@@ -75,7 +75,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/distributions/unur_stddistr.h
+++ b/unuran/src/distributions/unur_stddistr.h
@@ -11,7 +11,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/distributions/vc_copula.c
+++ b/unuran/src/distributions/vc_copula.c
@@ -19,7 +19,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/distributions/vc_multicauchy.c
+++ b/unuran/src/distributions/vc_multicauchy.c
@@ -40,7 +40,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/distributions/vc_multiexponential.c
+++ b/unuran/src/distributions/vc_multiexponential.c
@@ -51,7 +51,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/distributions/vc_multinormal.c
+++ b/unuran/src/distributions/vc_multinormal.c
@@ -41,7 +41,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/distributions/vc_multinormal_gen.c
+++ b/unuran/src/distributions/vc_multinormal_gen.c
@@ -10,7 +10,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/distributions/vc_multistudent.c
+++ b/unuran/src/distributions/vc_multistudent.c
@@ -35,7 +35,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/arou.c
+++ b/unuran/src/methods/arou.c
@@ -15,7 +15,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/arou.h
+++ b/unuran/src/methods/arou.h
@@ -15,7 +15,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/arou_struct.h
+++ b/unuran/src/methods/arou_struct.h
@@ -12,7 +12,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/ars.c
+++ b/unuran/src/methods/ars.c
@@ -15,7 +15,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/ars.h
+++ b/unuran/src/methods/ars.h
@@ -15,7 +15,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/ars_struct.h
+++ b/unuran/src/methods/ars_struct.h
@@ -12,7 +12,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/auto.c
+++ b/unuran/src/methods/auto.c
@@ -10,7 +10,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/auto.h
+++ b/unuran/src/methods/auto.h
@@ -15,7 +15,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/auto_struct.h
+++ b/unuran/src/methods/auto_struct.h
@@ -12,7 +12,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/cext.c
+++ b/unuran/src/methods/cext.c
@@ -11,7 +11,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/cext.h
+++ b/unuran/src/methods/cext.h
@@ -15,7 +15,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/cext_struct.h
+++ b/unuran/src/methods/cext_struct.h
@@ -12,7 +12,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/cstd.c
+++ b/unuran/src/methods/cstd.c
@@ -11,7 +11,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/cstd.h
+++ b/unuran/src/methods/cstd.h
@@ -16,7 +16,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/cstd_struct.h
+++ b/unuran/src/methods/cstd_struct.h
@@ -13,7 +13,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/dari.c
+++ b/unuran/src/methods/dari.c
@@ -15,7 +15,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/dari.h
+++ b/unuran/src/methods/dari.h
@@ -15,7 +15,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/dari_struct.h
+++ b/unuran/src/methods/dari_struct.h
@@ -12,7 +12,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/dau.c
+++ b/unuran/src/methods/dau.c
@@ -17,7 +17,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/dau.h
+++ b/unuran/src/methods/dau.h
@@ -15,7 +15,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/dau_struct.h
+++ b/unuran/src/methods/dau_struct.h
@@ -12,7 +12,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/dext.c
+++ b/unuran/src/methods/dext.c
@@ -11,7 +11,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/dext.h
+++ b/unuran/src/methods/dext.h
@@ -15,7 +15,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/dext_struct.h
+++ b/unuran/src/methods/dext_struct.h
@@ -12,7 +12,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/dgt.c
+++ b/unuran/src/methods/dgt.c
@@ -17,7 +17,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/dgt.h
+++ b/unuran/src/methods/dgt.h
@@ -15,7 +15,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/dgt_struct.h
+++ b/unuran/src/methods/dgt_struct.h
@@ -12,7 +12,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/dsrou.c
+++ b/unuran/src/methods/dsrou.c
@@ -23,7 +23,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/dsrou.h
+++ b/unuran/src/methods/dsrou.h
@@ -15,7 +15,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/dsrou_struct.h
+++ b/unuran/src/methods/dsrou_struct.h
@@ -12,7 +12,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/dss.c
+++ b/unuran/src/methods/dss.c
@@ -19,7 +19,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/dss.h
+++ b/unuran/src/methods/dss.h
@@ -15,7 +15,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/dss_struct.h
+++ b/unuran/src/methods/dss_struct.h
@@ -12,7 +12,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/dstd.c
+++ b/unuran/src/methods/dstd.c
@@ -11,7 +11,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/dstd.h
+++ b/unuran/src/methods/dstd.h
@@ -16,7 +16,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/dstd_struct.h
+++ b/unuran/src/methods/dstd_struct.h
@@ -13,7 +13,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/empk.c
+++ b/unuran/src/methods/empk.c
@@ -24,7 +24,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/empk.h
+++ b/unuran/src/methods/empk.h
@@ -15,7 +15,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/empk_struct.h
+++ b/unuran/src/methods/empk_struct.h
@@ -12,7 +12,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/empl.c
+++ b/unuran/src/methods/empl.c
@@ -20,7 +20,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/empl.h
+++ b/unuran/src/methods/empl.h
@@ -15,7 +15,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/empl_struct.h
+++ b/unuran/src/methods/empl_struct.h
@@ -12,7 +12,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/gibbs.c
+++ b/unuran/src/methods/gibbs.c
@@ -21,7 +21,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/gibbs.h
+++ b/unuran/src/methods/gibbs.h
@@ -15,7 +15,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/gibbs_struct.h
+++ b/unuran/src/methods/gibbs_struct.h
@@ -12,7 +12,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/hinv.c
+++ b/unuran/src/methods/hinv.c
@@ -19,7 +19,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/hinv.h
+++ b/unuran/src/methods/hinv.h
@@ -15,7 +15,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/hinv_struct.h
+++ b/unuran/src/methods/hinv_struct.h
@@ -12,7 +12,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/hist.c
+++ b/unuran/src/methods/hist.c
@@ -18,7 +18,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/hist.h
+++ b/unuran/src/methods/hist.h
@@ -15,7 +15,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/hist_struct.h
+++ b/unuran/src/methods/hist_struct.h
@@ -12,7 +12,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/hitro.c
+++ b/unuran/src/methods/hitro.c
@@ -21,7 +21,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/hitro.h
+++ b/unuran/src/methods/hitro.h
@@ -15,7 +15,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/hitro_struct.h
+++ b/unuran/src/methods/hitro_struct.h
@@ -12,7 +12,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/hrb.c
+++ b/unuran/src/methods/hrb.c
@@ -19,7 +19,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/hrb.h
+++ b/unuran/src/methods/hrb.h
@@ -15,7 +15,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/hrb_struct.h
+++ b/unuran/src/methods/hrb_struct.h
@@ -12,7 +12,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/hrd.c
+++ b/unuran/src/methods/hrd.c
@@ -17,7 +17,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/hrd.h
+++ b/unuran/src/methods/hrd.h
@@ -15,7 +15,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/hrd_struct.h
+++ b/unuran/src/methods/hrd_struct.h
@@ -12,7 +12,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/hri.c
+++ b/unuran/src/methods/hri.c
@@ -17,7 +17,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/hri.h
+++ b/unuran/src/methods/hri.h
@@ -15,7 +15,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/hri_struct.h
+++ b/unuran/src/methods/hri_struct.h
@@ -12,7 +12,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/itdr.c
+++ b/unuran/src/methods/itdr.c
@@ -23,7 +23,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/itdr.h
+++ b/unuran/src/methods/itdr.h
@@ -15,7 +15,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/itdr_struct.h
+++ b/unuran/src/methods/itdr_struct.h
@@ -12,7 +12,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/mcorr.c
+++ b/unuran/src/methods/mcorr.c
@@ -14,7 +14,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/mcorr.h
+++ b/unuran/src/methods/mcorr.h
@@ -15,7 +15,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/mcorr_struct.h
+++ b/unuran/src/methods/mcorr_struct.h
@@ -12,7 +12,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/mvstd.c
+++ b/unuran/src/methods/mvstd.c
@@ -11,7 +11,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/mvstd.h
+++ b/unuran/src/methods/mvstd.h
@@ -16,7 +16,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/mvstd_struct.h
+++ b/unuran/src/methods/mvstd_struct.h
@@ -13,7 +13,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/mvtdr.c
+++ b/unuran/src/methods/mvtdr.c
@@ -15,7 +15,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/mvtdr.h
+++ b/unuran/src/methods/mvtdr.h
@@ -15,7 +15,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/mvtdr_debug.h
+++ b/unuran/src/methods/mvtdr_debug.h
@@ -15,7 +15,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/mvtdr_info.h
+++ b/unuran/src/methods/mvtdr_info.h
@@ -15,7 +15,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/mvtdr_init.h
+++ b/unuran/src/methods/mvtdr_init.h
@@ -15,7 +15,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/mvtdr_newset.h
+++ b/unuran/src/methods/mvtdr_newset.h
@@ -15,7 +15,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/mvtdr_sample.h
+++ b/unuran/src/methods/mvtdr_sample.h
@@ -15,7 +15,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/mvtdr_struct.h
+++ b/unuran/src/methods/mvtdr_struct.h
@@ -12,7 +12,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/ninv.c
+++ b/unuran/src/methods/ninv.c
@@ -17,7 +17,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/ninv.h
+++ b/unuran/src/methods/ninv.h
@@ -15,7 +15,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/ninv_debug.h
+++ b/unuran/src/methods/ninv_debug.h
@@ -10,7 +10,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
  *****************************************************************************/
 

--- a/unuran/src/methods/ninv_info.h
+++ b/unuran/src/methods/ninv_info.h
@@ -10,7 +10,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
  *****************************************************************************/
 

--- a/unuran/src/methods/ninv_init.h
+++ b/unuran/src/methods/ninv_init.h
@@ -10,7 +10,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
  *****************************************************************************/
 

--- a/unuran/src/methods/ninv_newset.h
+++ b/unuran/src/methods/ninv_newset.h
@@ -10,7 +10,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
  *****************************************************************************/
 

--- a/unuran/src/methods/ninv_newton.h
+++ b/unuran/src/methods/ninv_newton.h
@@ -10,7 +10,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
  *****************************************************************************
  *                                                                           *

--- a/unuran/src/methods/ninv_regula.h
+++ b/unuran/src/methods/ninv_regula.h
@@ -10,7 +10,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
  *****************************************************************************
  *                                                                           *

--- a/unuran/src/methods/ninv_sample.h
+++ b/unuran/src/methods/ninv_sample.h
@@ -10,7 +10,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
  *****************************************************************************/
 

--- a/unuran/src/methods/ninv_struct.h
+++ b/unuran/src/methods/ninv_struct.h
@@ -12,7 +12,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/norta.c
+++ b/unuran/src/methods/norta.c
@@ -14,7 +14,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/norta.h
+++ b/unuran/src/methods/norta.h
@@ -15,7 +15,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/norta_struct.h
+++ b/unuran/src/methods/norta_struct.h
@@ -12,7 +12,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/nrou.c
+++ b/unuran/src/methods/nrou.c
@@ -23,7 +23,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/nrou.h
+++ b/unuran/src/methods/nrou.h
@@ -15,7 +15,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/nrou_struct.h
+++ b/unuran/src/methods/nrou_struct.h
@@ -12,7 +12,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/pinv_struct.h
+++ b/unuran/src/methods/pinv_struct.h
@@ -12,7 +12,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/srou.c
+++ b/unuran/src/methods/srou.c
@@ -22,7 +22,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/srou.h
+++ b/unuran/src/methods/srou.h
@@ -15,7 +15,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/srou_struct.h
+++ b/unuran/src/methods/srou_struct.h
@@ -12,7 +12,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/ssr.c
+++ b/unuran/src/methods/ssr.c
@@ -22,7 +22,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/ssr.h
+++ b/unuran/src/methods/ssr.h
@@ -15,7 +15,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/ssr_struct.h
+++ b/unuran/src/methods/ssr_struct.h
@@ -12,7 +12,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/tabl.c
+++ b/unuran/src/methods/tabl.c
@@ -16,7 +16,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/tabl.h
+++ b/unuran/src/methods/tabl.h
@@ -15,7 +15,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/tabl_debug.h
+++ b/unuran/src/methods/tabl_debug.h
@@ -16,7 +16,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/tabl_info.h
+++ b/unuran/src/methods/tabl_info.h
@@ -15,7 +15,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/tabl_init.h
+++ b/unuran/src/methods/tabl_init.h
@@ -16,7 +16,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/tabl_newset.h
+++ b/unuran/src/methods/tabl_newset.h
@@ -16,7 +16,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/tabl_sample.h
+++ b/unuran/src/methods/tabl_sample.h
@@ -16,7 +16,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/tabl_struct.h
+++ b/unuran/src/methods/tabl_struct.h
@@ -12,7 +12,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/tdr.c
+++ b/unuran/src/methods/tdr.c
@@ -15,7 +15,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/tdr.h
+++ b/unuran/src/methods/tdr.h
@@ -15,7 +15,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/tdr_debug.h
+++ b/unuran/src/methods/tdr_debug.h
@@ -15,7 +15,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/tdr_gw_debug.h
+++ b/unuran/src/methods/tdr_gw_debug.h
@@ -14,7 +14,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/tdr_gw_init.h
+++ b/unuran/src/methods/tdr_gw_init.h
@@ -14,7 +14,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/tdr_gw_sample.h
+++ b/unuran/src/methods/tdr_gw_sample.h
@@ -14,7 +14,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/tdr_ia_sample.h
+++ b/unuran/src/methods/tdr_ia_sample.h
@@ -15,7 +15,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/tdr_info.h
+++ b/unuran/src/methods/tdr_info.h
@@ -14,7 +14,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/tdr_init.h
+++ b/unuran/src/methods/tdr_init.h
@@ -15,7 +15,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/tdr_newset.h
+++ b/unuran/src/methods/tdr_newset.h
@@ -15,7 +15,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/tdr_ps_debug.h
+++ b/unuran/src/methods/tdr_ps_debug.h
@@ -14,7 +14,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/tdr_ps_init.h
+++ b/unuran/src/methods/tdr_ps_init.h
@@ -14,7 +14,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/tdr_ps_sample.h
+++ b/unuran/src/methods/tdr_ps_sample.h
@@ -14,7 +14,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/tdr_sample.h
+++ b/unuran/src/methods/tdr_sample.h
@@ -15,7 +15,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/tdr_struct.h
+++ b/unuran/src/methods/tdr_struct.h
@@ -12,7 +12,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/unif.c
+++ b/unuran/src/methods/unif.c
@@ -10,7 +10,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/unif.h
+++ b/unuran/src/methods/unif.h
@@ -16,7 +16,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/unif_struct.h
+++ b/unuran/src/methods/unif_struct.h
@@ -13,7 +13,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/unur_methods.h
+++ b/unuran/src/methods/unur_methods.h
@@ -11,7 +11,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/unur_methods_source.h
+++ b/unuran/src/methods/unur_methods_source.h
@@ -12,7 +12,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/utdr.c
+++ b/unuran/src/methods/utdr.c
@@ -32,7 +32,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/utdr.h
+++ b/unuran/src/methods/utdr.h
@@ -15,7 +15,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/utdr_struct.h
+++ b/unuran/src/methods/utdr_struct.h
@@ -12,7 +12,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/vempk.c
+++ b/unuran/src/methods/vempk.c
@@ -21,7 +21,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/vempk.h
+++ b/unuran/src/methods/vempk.h
@@ -15,7 +15,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/vempk_struct.h
+++ b/unuran/src/methods/vempk_struct.h
@@ -12,7 +12,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/vnrou.c
+++ b/unuran/src/methods/vnrou.c
@@ -23,7 +23,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/vnrou.h
+++ b/unuran/src/methods/vnrou.h
@@ -15,7 +15,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/vnrou_struct.h
+++ b/unuran/src/methods/vnrou_struct.h
@@ -12,7 +12,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/x_gen.c
+++ b/unuran/src/methods/x_gen.c
@@ -10,7 +10,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/x_gen.h
+++ b/unuran/src/methods/x_gen.h
@@ -15,7 +15,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/x_gen_source.h
+++ b/unuran/src/methods/x_gen_source.h
@@ -15,7 +15,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/methods/x_gen_struct.h
+++ b/unuran/src/methods/x_gen_struct.h
@@ -14,7 +14,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/parser/functparser.c
+++ b/unuran/src/parser/functparser.c
@@ -18,7 +18,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/parser/functparser_debug.h
+++ b/unuran/src/parser/functparser_debug.h
@@ -10,7 +10,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/parser/functparser_deriv.h
+++ b/unuran/src/parser/functparser_deriv.h
@@ -10,7 +10,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/parser/functparser_eval.h
+++ b/unuran/src/parser/functparser_eval.h
@@ -10,7 +10,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/parser/functparser_init.h
+++ b/unuran/src/parser/functparser_init.h
@@ -10,7 +10,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/parser/functparser_parser.h
+++ b/unuran/src/parser/functparser_parser.h
@@ -10,7 +10,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/parser/functparser_scanner.h
+++ b/unuran/src/parser/functparser_scanner.h
@@ -10,7 +10,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/parser/functparser_source.h
+++ b/unuran/src/parser/functparser_source.h
@@ -11,7 +11,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/parser/functparser_stringgen.h
+++ b/unuran/src/parser/functparser_stringgen.h
@@ -10,7 +10,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/parser/functparser_struct.h
+++ b/unuran/src/parser/functparser_struct.h
@@ -11,7 +11,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/parser/functparser_symbols.h
+++ b/unuran/src/parser/functparser_symbols.h
@@ -20,7 +20,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/parser/parser.c
+++ b/unuran/src/parser/parser.c
@@ -15,7 +15,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/parser/parser.h
+++ b/unuran/src/parser/parser.h
@@ -11,7 +11,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/parser/parser_source.h
+++ b/unuran/src/parser/parser_source.h
@@ -11,7 +11,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/parser/stringparser.c
+++ b/unuran/src/parser/stringparser.c
@@ -106,7 +106,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/parser/stringparser_lists.h
+++ b/unuran/src/parser/stringparser_lists.h
@@ -26,7 +26,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/specfunct/unur_specfunct_source.h
+++ b/unuran/src/specfunct/unur_specfunct_source.h
@@ -12,7 +12,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/tests/chi2test.c
+++ b/unuran/src/tests/chi2test.c
@@ -14,7 +14,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/tests/correlation.c
+++ b/unuran/src/tests/correlation.c
@@ -16,7 +16,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/tests/countpdf.c
+++ b/unuran/src/tests/countpdf.c
@@ -10,7 +10,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/tests/counturn.c
+++ b/unuran/src/tests/counturn.c
@@ -10,7 +10,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/tests/moments.c
+++ b/unuran/src/tests/moments.c
@@ -10,7 +10,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/tests/printsample.c
+++ b/unuran/src/tests/printsample.c
@@ -10,7 +10,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/tests/quantiles.c
+++ b/unuran/src/tests/quantiles.c
@@ -10,7 +10,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/tests/tests.c
+++ b/unuran/src/tests/tests.c
@@ -10,7 +10,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/tests/timing.c
+++ b/unuran/src/tests/timing.c
@@ -10,7 +10,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/tests/unuran_tests.h
+++ b/unuran/src/tests/unuran_tests.h
@@ -11,7 +11,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/unur_cookies.h
+++ b/unuran/src/unur_cookies.h
@@ -15,7 +15,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/unur_source.h
+++ b/unuran/src/unur_source.h
@@ -11,7 +11,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/unur_struct.h
+++ b/unuran/src/unur_struct.h
@@ -12,7 +12,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/unur_typedefs.h
+++ b/unuran/src/unur_typedefs.h
@@ -12,7 +12,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/unuran_config.h
+++ b/unuran/src/unuran_config.h
@@ -10,7 +10,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/urng/urng.c
+++ b/unuran/src/urng/urng.c
@@ -10,7 +10,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/urng/urng.h
+++ b/unuran/src/urng/urng.h
@@ -15,7 +15,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/urng/urng_default.c
+++ b/unuran/src/urng/urng_default.c
@@ -11,7 +11,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/urng/urng_set.c
+++ b/unuran/src/urng/urng_set.c
@@ -11,7 +11,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/urng/urng_source.h
+++ b/unuran/src/urng/urng_source.h
@@ -10,7 +10,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/urng/urng_struct.h
+++ b/unuran/src/urng/urng_struct.h
@@ -10,7 +10,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/urng/urng_unuran.c
+++ b/unuran/src/urng/urng_unuran.c
@@ -10,7 +10,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/utils/debug.c
+++ b/unuran/src/utils/debug.c
@@ -10,7 +10,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/utils/debug.h
+++ b/unuran/src/utils/debug.h
@@ -11,7 +11,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/utils/debug_source.h
+++ b/unuran/src/utils/debug_source.h
@@ -11,7 +11,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/utils/eigensystem.c
+++ b/unuran/src/utils/eigensystem.c
@@ -17,7 +17,9 @@
  *   Translated into C and adapted for UNU.RAN by Roman Karawatzki.          *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/utils/error.c
+++ b/unuran/src/utils/error.c
@@ -10,7 +10,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/utils/error.h
+++ b/unuran/src/utils/error.h
@@ -11,7 +11,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/utils/error_source.h
+++ b/unuran/src/utils/error_source.h
@@ -11,7 +11,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/utils/fmax.c
+++ b/unuran/src/utils/fmax.c
@@ -10,7 +10,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/utils/fmax_source.h
+++ b/unuran/src/utils/fmax_source.h
@@ -11,7 +11,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/utils/hooke_source.h
+++ b/unuran/src/utils/hooke_source.h
@@ -12,7 +12,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/utils/lobatto_struct.h
+++ b/unuran/src/utils/lobatto_struct.h
@@ -11,7 +11,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/utils/mrou_rectangle.c
+++ b/unuran/src/utils/mrou_rectangle.c
@@ -14,7 +14,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/utils/mrou_rectangle_source.h
+++ b/unuran/src/utils/mrou_rectangle_source.h
@@ -13,7 +13,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/utils/mrou_rectangle_struct.h
+++ b/unuran/src/utils/mrou_rectangle_struct.h
@@ -13,7 +13,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/utils/slist.c
+++ b/unuran/src/utils/slist.c
@@ -10,7 +10,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/utils/slist.h
+++ b/unuran/src/utils/slist.h
@@ -11,7 +11,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/utils/slist_struct.h
+++ b/unuran/src/utils/slist_struct.h
@@ -11,7 +11,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/utils/stream.c
+++ b/unuran/src/utils/stream.c
@@ -10,7 +10,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/utils/stream.h
+++ b/unuran/src/utils/stream.h
@@ -11,7 +11,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/utils/stream_source.h
+++ b/unuran/src/utils/stream_source.h
@@ -11,7 +11,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/utils/string.c
+++ b/unuran/src/utils/string.c
@@ -10,7 +10,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/utils/string_source.h
+++ b/unuran/src/utils/string_source.h
@@ -11,7 +11,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/utils/string_struct.h
+++ b/unuran/src/utils/string_struct.h
@@ -11,7 +11,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/utils/umalloc.c
+++ b/unuran/src/utils/umalloc.c
@@ -10,7 +10,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/utils/umalloc_source.h
+++ b/unuran/src/utils/umalloc_source.h
@@ -11,7 +11,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/utils/umath.c
+++ b/unuran/src/utils/umath.c
@@ -10,7 +10,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/utils/umath.h
+++ b/unuran/src/utils/umath.h
@@ -12,7 +12,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/utils/umath_source.h
+++ b/unuran/src/utils/umath_source.h
@@ -12,7 +12,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/utils/unur_errno.h
+++ b/unuran/src/utils/unur_errno.h
@@ -11,7 +11,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/utils/unur_fp.c
+++ b/unuran/src/utils/unur_fp.c
@@ -10,7 +10,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/utils/unur_fp_source.h
+++ b/unuran/src/utils/unur_fp_source.h
@@ -11,7 +11,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/utils/unur_math_source.h
+++ b/unuran/src/utils/unur_math_source.h
@@ -12,7 +12,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/utils/vector.c
+++ b/unuran/src/utils/vector.c
@@ -10,7 +10,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/unuran/src/utils/vector_source.h
+++ b/unuran/src/utils/vector_source.h
@@ -10,7 +10,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *

--- a/urng_default_mod.c
+++ b/urng_default_mod.c
@@ -11,7 +11,9 @@
  *                                                                           *
  *****************************************************************************
  *                                                                           *
-
+ *   Copyright (c) 2000-2022 Wolfgang Hoermann and Josef Leydold             *
+ *   Department of Statistics and Mathematics, WU Wien, Austria              *
+ *   SPDX-License-Identifier: BSD-3-Clause                                   *
  *                                                                           *
 
  *                                                                           *


### PR DESCRIPTION
Revert the last commit in #5. As suggested by [this comment](https://github.com/scipy/unuran/pull/5#issuecomment-1124241561), I have also added a reference to BSD3 clause licence.

```
 *   Copyright (c) 2000-2006 Wolfgang Hoermann and Josef Leydold             *
 *   Department of Statistics and Mathematics, WU Wien, Austria              *
 *   SPDX-License-Identifier: BSD-3-Clause                                   *
```