### PR TITLE
MAINT: automatically remove GPL license code

### DIFF
--- a/get_and_clean_unuran.py
+++ b/get_and_clean_unuran.py
@@ -127,7 +127,8 @@ def _download_unuran(version: str, logger: logging.Logger) -> None:
                 shutil.rmtree(base / "unuran" / dir_to_remove)
 
         # Unwanted files.
-        files_to_remove = ["src/unuran.h.in", "acinclude.m4", "aclocal.m4", "autogen.sh", "configure", "COPYING", "INSTALL", "NEWS", "UPGRADE"]
+        files_to_remove = ["src/unuran.h.in", "acinclude.m4", "aclocal.m4", "autogen.sh", "configure",
+                           "COPYING", "INSTALL", "NEWS", "UPGRADE", "src/specfunct/log1p.c"]
         for file_to_remove in files_to_remove:
             if (base / "unuran" / file_to_remove).exists():
                 os.remove(base / "unuran" / file_to_remove)


### PR DESCRIPTION
Follow up to #9

Thanks for sorting that @tylerjereddy, I thought it would be a good idea to automatically remove that file so that if we update the version in the future we don't accidentally reintroduce it.