### PR TITLE
MAINT: fix incorrect function prototype in pinv.c

### DIFF
--- a/unuran/src/methods/pinv.c
+++ b/unuran/src/methods/pinv.c
@@ -422,7 +422,7 @@ static int _unur_pinv_newton_testpoints (double *utest, double ui[], int order);
 /* [2c.] calculate the local maxima of the interpolation polynomial          */
 /*---------------------------------------------------------------------------*/
 
-static int _unur_pinv_cubic_hermite_is_monotone();
+static int _unur_pinv_cubic_hermite_is_monotone(struct unur_gen *gen, double *ui, double *zi, double *xval);
 /*---------------------------------------------------------------------------*/
 /* [2c.] check monotonicity of cubic Hermite interpolation                   */
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
This resulted in this warning with recent Clang versions:
```
warning: a function definition without a prototype is deprecated in all versions of C and is not supported in C2x [-Wdeprecated-non-prototype]
```

After making this fix, I wanted to contribute it upstream as well - and discovered that the exact same fix had been made there already.